### PR TITLE
Add UNENCRYPTED environment variable

### DIFF
--- a/docker-compose/.env.example
+++ b/docker-compose/.env.example
@@ -6,6 +6,9 @@ CRON_SCHEDULE="0 */4 * * *"
 # If you want to skip backup on startup, set CRON_BACKUP_ONLY=1 otherwise CRON_BACKUP_ONLY=0
 CRON_BACKUP_ONLY=0
 
+# Set UNENCRYPTED=1 to bypass key generation and allow the backup to be unencrypted
+UNENCRYPTED=0
+
 # Use of the PBS_API_KEY_NAME and PBS_API_KEY_SECRET is recommended!
 # If unset, ensure PBS_USER and PBS_PASSWORD are set.
 PBS_API_KEY_NAME="username@pam!test"

--- a/docker/src/s6-services/key_setup/run
+++ b/docker/src/s6-services/key_setup/run
@@ -20,6 +20,12 @@ handle_error() {
 }
 trap handle_error ERR
 
+# Check if encryption is disabled via environment variable
+if [ "${UNENCRYPTED}" = "1" ]; then
+    echo "Encrypted backups are disabled. Skipping key setup process."
+    exit 0
+fi
+
 client_encryption_keyfile="/root/.config/proxmox-backup/encryption-key.json"
 master_private_keyfile="/root/.config/proxmox-backup/master-private.pem"
 master_public_keyfile="/root/.config/proxmox-backup/master-public.pem"


### PR DESCRIPTION
Add UNENCRYPTED Environment Variable
This change pretty self-explanatory.

By setting UNENCRYPTED=1 in your environment variables, it bypass the key generation process and allows you to backup without encryption enabled.

Fully regression tested with live instance of PBS.